### PR TITLE
New proposer block transaction history after confirmed

### DIFF
--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -226,8 +226,8 @@ func FinishBallot(st *sebakstorage.LevelDBBackend, ballot Ballot, transactionPoo
 		tx := transactions[hash]
 
 		// save in `BlockTransactionHistory`
-		bth := NewBlockTransactionHistoryFromTransaction(tx, nil)
-		if err = bth.Save(st); err != nil {
+		if err = StoreBlockTransactionInHistory(st, tx, nil); err != nil {
+			ts.Discard()
 			return
 		}
 

--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -224,9 +224,14 @@ func FinishBallot(st *sebakstorage.LevelDBBackend, ballot Ballot, transactionPoo
 
 	for _, hash := range ballot.B.Proposed.Transactions {
 		tx := transactions[hash]
-		raw, _ := json.Marshal(tx)
 
-		bt := NewBlockTransactionFromTransaction(tx, raw)
+		// save in `BlockTransactionHistory`
+		bth := NewBlockTransactionHistoryFromTransaction(tx, nil)
+		if err = bth.Save(st); err != nil {
+			return
+		}
+
+		bt := NewBlockTransactionFromTransaction(tx)
 		if err = bt.Save(ts); err != nil {
 			ts.Discard()
 			return

--- a/lib/block_transaction.go
+++ b/lib/block_transaction.go
@@ -48,11 +48,13 @@ type BlockTransaction struct {
 	isSaved     bool
 }
 
-func NewBlockTransactionFromTransaction(tx Transaction, message []byte) BlockTransaction {
+func NewBlockTransactionFromTransaction(tx Transaction) BlockTransaction {
 	var opHashes []string
 	for _, op := range tx.B.Operations {
 		opHashes = append(opHashes, NewBlockOperationKey(op, tx))
 	}
+
+	raw, _ := tx.Serialize()
 
 	return BlockTransaction{
 		Hash:               tx.H.Hash,
@@ -66,7 +68,7 @@ func NewBlockTransactionFromTransaction(tx Transaction, message []byte) BlockTra
 		Amount:             tx.TotalAmount(true),
 
 		Created: tx.H.Created,
-		Message: message,
+		Message: raw,
 
 		transaction: tx,
 	}

--- a/lib/block_transaction_history.go
+++ b/lib/block_transaction_history.go
@@ -88,3 +88,26 @@ func GetBlockTransactionHistory(st *sebakstorage.LevelDBBackend, hash string) (b
 func ExistsBlockTransactionHistory(st *sebakstorage.LevelDBBackend, hash string) (bool, error) {
 	return st.Has(GetBlockTransactionHistoryKey(hash))
 }
+
+func StoreBlockTransactionInHistory(st *sebakstorage.LevelDBBackend, tx Transaction, reason error) (err error) {
+	if err == sebakerror.ErrorBlockAlreadyExists {
+		return
+	}
+
+	if err == sebakerror.ErrorNewButKnownMessage {
+		return
+	}
+
+	var found bool
+	found, err = ExistsBlockTransactionHistory(st, tx.GetHash())
+	if err != nil || found {
+		return
+	}
+
+	bth := NewBlockTransactionHistoryFromTransaction(tx, reason)
+	if err = bth.Save(st); err != nil {
+		return
+	}
+
+	return
+}

--- a/lib/node_runner_checker.go
+++ b/lib/node_runner_checker.go
@@ -67,11 +67,6 @@ func CheckNodeRunnerHandleMessageHistory(c sebakcommon.Checker, args ...interfac
 		return
 	}
 
-	bt := NewTransactionHistoryFromTransaction(checker.Transaction, checker.Message.Data)
-	if err = bt.Save(checker.NodeRunner.Storage()); err != nil {
-		return
-	}
-
 	checker.NodeRunner.Log().Debug("saved in history", "transaction", checker.Transaction.GetHash())
 
 	return

--- a/lib/test.go
+++ b/lib/test.go
@@ -32,8 +32,7 @@ func TestMakeNewBlockOperation(networkID []byte, n int) (bos []BlockOperation) {
 func TestMakeNewBlockTransaction(networkID []byte, n int) BlockTransaction {
 	_, tx := TestMakeTransaction(networkID, n)
 
-	a, _ := tx.Serialize()
-	return NewBlockTransactionFromTransaction(tx, a)
+	return NewBlockTransactionFromTransaction(tx)
 }
 
 func TestMakeOperationBodyPayment(amount int, addressList ...string) OperationBodyPayment {


### PR DESCRIPTION
All incoming `Transaction`s will be saved in `BlockTransactionHistory`. If it could not be saved in `Block`, it will be saved with error.